### PR TITLE
Bump dotnet version to 8, due to 6 and 7 EOLs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,6 @@ jobs:
         # Test oldest and most current supported versions, per:
         # https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core
         dotnet-version:
-          - '6.x'
           - '8.x'
     steps:
 

--- a/dotnet/CASE2GeoJSON.csproj
+++ b/dotnet/CASE2GeoJSON.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
References:
* https://devblogs.microsoft.com/dotnet/dotnet-6-end-of-support/